### PR TITLE
make image dimensions divisible by two, which is a pytorch requirement

### DIFF
--- a/testbot.py
+++ b/testbot.py
@@ -716,6 +716,13 @@ Example: `{0}upscale www.imageurl.com/image.png 4xBox.pth -downscale 4 -filter p
         """
         img = img * 1.0 / np.iinfo(img.dtype).max
 
+        # Make image dimensions divisible by two, which is a pytorch requirement
+        # https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/PixelShuffle.cpp#L46-L51
+        # to prevent
+        #   RuntimeError: pixel_unshuffle expects width to be divisible by downscale_factor, but input.size(-1)=613 is not divisible by 2
+        # If either dimension is odd, we truncate the last row or column, which is more user-friendly than adding empty pixels
+        img = img[0:img.shape[0] - img.shape[0] % 2, 0:img.shape[1] - img.shape[1] % 2]
+
         if (
             img.ndim == 3
             and img.shape[2] == 4


### PR DESCRIPTION
https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/PixelShuffle.cpp#L46-L51

Prevents

> RuntimeError: pixel_unshuffle expects width to be divisible by downscale_factor, but input.size(-1)=613 is not divisible by 2

Tested with `(498, 613)` which was cropped to `(498, 612)`

A much more complex fix would be to add an extra row, and then crop the result depending on scale factor. But a single removed row when we are upscaling through discord isn't a big deal.