### PR TITLE
fix(pixel_unshuffle): Allow images with dimensions not divisible by scale factor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ OPTIONAL: Enable the virtual environment:
 Install requirements: `pip install -r requirements.txt`
 If not using a virtual environment, use pip3 instead of pip.
 
-Visit the PyTorch website here and generate the correct command for your system.
+Visit the [PyTorch website](https://pytorch.org/) and generate the correct command for your system.
 For Package hit "Pip", for Language hit "Python".
 If you are using a modern Nvidia card with up-to-date drivers select the latest CUDA for Compute Platform.
 If using AMD or no GPU at all, hit CPU instead.

--- a/utils/architecture/RRDB.py
+++ b/utils/architecture/RRDB.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 import torch
 import torch.nn as nn
 import utils.architecture.block as B
+import torch.nn.functional as F
 
 
 # Borrowed from https://github.com/rlaphoenix/VSGAN/blob/master/vsgan/archs/ESRGAN.py
@@ -239,5 +240,15 @@ class RRDBNet(nn.Module):
 
     def forward(self, x):
         if self.shuffle_factor:
+            _, _, h, w = x.size()
+            mod_pad_h = (
+                                self.shuffle_factor - h % self.shuffle_factor
+                        ) % self.shuffle_factor
+            mod_pad_w = (
+                                self.shuffle_factor - w % self.shuffle_factor
+                        ) % self.shuffle_factor
+            x = F.pad(x, (0, mod_pad_w, 0, mod_pad_h), "reflect")
             x = torch.pixel_unshuffle(x, downscale_factor=self.shuffle_factor)
+            x = self.model(x)
+            return x[:, :, : h * self.scale, : w * self.scale]
         return self.model(x)


### PR DESCRIPTION
Allows some x2 models that require dimensions divisible by 2 to work properly.
As suggested by [Mikulas](https://github.com/joeyballentine/ESRGAN-Bot/issues?q=is%3Apr+is%3Aopen+author%3AMikulas), implemented using Joey's fix from Chainner :)